### PR TITLE
Allow oembed configuration

### DIFF
--- a/lib/film_snob.rb
+++ b/lib/film_snob.rb
@@ -5,25 +5,29 @@ require "film_snob/exceptions"
 class FilmSnob
   attr_reader :url, :video
 
-  def initialize(url)
+  def initialize(url, options={})
     @url = url
-    @video = FilmSnob::UrlToVideo.new(url).video
+    @video = UrlToVideo.new(url, options).video
   end
 
   def watchable?
     !video.nil?
   end
 
-  def method_missing(m)
-    if [:site, :id, :clean_url, :title, :html].include?(m)
-      complain_about_bad_urls!(m)
-      video.send(m)
+  def method_missing(message)
+    if delegated_video_methods.include?(message)
+      complain_about_bad_urls!(message)
+      video.send(message)
     else
       super
     end
   end
 
   private
+  
+    def delegated_video_methods
+      [:site, :id, :clean_url, :title, :html]
+    end
 
     def complain_about_bad_urls!(method)
       raise NotSupportedURLError.new("Can not call FilmSnob##{method} because #{url} is not a supported URL.") unless watchable?

--- a/lib/film_snob/url_to_video.rb
+++ b/lib/film_snob/url_to_video.rb
@@ -11,14 +11,15 @@ class FilmSnob
       Hulu
     ]
 
-    attr_reader :url
+    attr_reader :url, :options
 
-    def initialize(url)
+    def initialize(url, options)
       @url = url
+      @options = options
     end
 
     def video
-      site.nil?? nil : site.new(url)
+      site.nil?? nil : site.new(url, options)
     end
 
     private

--- a/lib/film_snob/video_site.rb
+++ b/lib/film_snob/video_site.rb
@@ -3,10 +3,11 @@ require 'httparty'
 class FilmSnob
   class VideoSite
 
-    attr_reader :url
+    attr_reader :url, :options
 
-    def initialize(url)
+    def initialize(url, options)
       @url = url
+      @options = options
     end
 
     def id
@@ -48,7 +49,7 @@ class FilmSnob
       def oembed
         @oembed ||= HTTParty.get(
           self.class.oembed_endpoint,
-          query: { url: clean_url }
+          query: { url: clean_url }.merge(options)
         )
       end
 

--- a/spec/cassettes/bad_youtube_url.yml
+++ b/spec/cassettes/bad_youtube_url.yml
@@ -13,31 +13,29 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Sun, 13 Apr 2014 22:47:31 GMT
+      - Tue, 15 Apr 2014 02:52:18 GMT
       Server:
       - gwiseguy/2.0
-      Content-Type:
-      - text/html; charset=utf-8
-      X-Xss-Protection:
-      - 1; mode=block; report=https://www.google.com/appserve/security-bugs/log/youtube
-      X-Frame-Options:
-      - ALLOWALL
-      Cache-Control:
-      - no-cache
+      X-Content-Type-Options:
+      - nosniff
       P3p:
       - CP="This is not a P3P policy! See http://support.google.com/accounts/bin/answer.py?answer=151657&hl=en
         for more info."
+      X-Frame-Options:
+      - ALLOWALL
       Expires:
       - Tue, 27 Apr 1971 19:44:06 EST
-      X-Content-Type-Options:
-      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block; report=https://www.google.com/appserve/security-bugs/log/youtube
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - text/html; charset=utf-8
       Content-Length:
       - '9'
-      Alternate-Protocol:
-      - 443:quic
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: Not Found
     http_version: 
-  recorded_at: Sun, 13 Apr 2014 22:47:31 GMT
+  recorded_at: Tue, 15 Apr 2014 02:52:19 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/billy.yml
+++ b/spec/cassettes/billy.yml
@@ -13,38 +13,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 13 Apr 2014 22:37:31 GMT
+      - Tue, 15 Apr 2014 02:52:15 GMT
       Server:
       - gwiseguy/2.0
+      X-Frame-Options:
+      - ALLOWALL
+      X-Xss-Protection:
+      - 1; mode=block; report=https://www.google.com/appserve/security-bugs/log/youtube
+      Expires:
+      - Tue, 27 Apr 1971 19:44:06 EST
       X-Content-Type-Options:
       - nosniff
       P3p:
       - CP="This is not a P3P policy! See http://support.google.com/accounts/bin/answer.py?answer=151657&hl=en
         for more info."
-      X-Xss-Protection:
-      - 1; mode=block; report=https://www.google.com/appserve/security-bugs/log/youtube
       Content-Type:
       - application/json
-      X-Frame-Options:
-      - ALLOWALL
-      Expires:
-      - Tue, 27 Apr 1971 19:44:06 EST
       Cache-Control:
       - no-cache
-      Alternate-Protocol:
-      - 443:quic
       Transfer-Encoding:
       - chunked
     body:
-      encoding: UTF-8
-      string: '{"title": "Billy on the Street: Amateur Speed Sketching!", "author_name":
-        "billyonthestreettv", "height": 270, "width": 480, "thumbnail_width": 480,
-        "author_url": "http:\/\/www.youtube.com\/user\/billyonthestreettv", "thumbnail_height":
-        360, "type": "video", "thumbnail_url": "http:\/\/i1.ytimg.com\/vi\/7q5Ltr0qc8c\/hqdefault.jpg",
-        "provider_url": "http:\/\/www.youtube.com\/", "html": "\u003ciframe width=\"480\"
-        height=\"270\" src=\"http:\/\/www.youtube.com\/embed\/7q5Ltr0qc8c?feature=oembed\"
-        frameborder=\"0\" allowfullscreen\u003e\u003c\/iframe\u003e", "version": "1.0",
-        "provider_name": "YouTube"}'
+      encoding: US-ASCII
+      string: ! '{"type": "video", "provider_url": "http:\/\/www.youtube.com\/", "thumbnail_url":
+        "http:\/\/i1.ytimg.com\/vi\/7q5Ltr0qc8c\/hqdefault.jpg", "thumbnail_height":
+        360, "width": 480, "provider_name": "YouTube", "author_url": "http:\/\/www.youtube.com\/user\/billyonthestreettv",
+        "title": "Billy on the Street: Amateur Speed Sketching!", "thumbnail_width":
+        480, "version": "1.0", "html": "\u003ciframe width=\"480\" height=\"270\"
+        src=\"http:\/\/www.youtube.com\/embed\/7q5Ltr0qc8c?feature=oembed\" frameborder=\"0\"
+        allowfullscreen\u003e\u003c\/iframe\u003e", "height": 270, "author_name":
+        "billyonthestreettv"}'
     http_version: 
-  recorded_at: Sun, 13 Apr 2014 22:37:31 GMT
+  recorded_at: Tue, 15 Apr 2014 02:52:17 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/harmon.yml
+++ b/spec/cassettes/harmon.yml
@@ -25,19 +25,19 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - max-age=3568
+      - max-age=3600
       Date:
-      - Sun, 13 Apr 2014 22:40:14 GMT
+      - Tue, 15 Apr 2014 02:52:16 GMT
       Connection:
       - keep-alive
     body:
-      encoding: UTF-8
-      string: '{"cache_age":3600,"type":"video","large_thumbnail_url":"http://ib.huluim.com/video/50172061?size=512x288&caller=h1o&img=i","height":296,"html":"<iframe
+      encoding: US-ASCII
+      string: ! '{"cache_age":3600,"type":"video","large_thumbnail_url":"http://ib.huluim.com/video/50172061?size=512x288&caller=h1o&img=i","height":296,"html":"<iframe
         width=\"512\" height=\"296\" src=\"http://www.hulu.com/embed.html?eid=CbtnRM8PBJsCfZpUy2V3Yg\"
         frameborder=\"0\" scrolling=\"no\" webkitAllowFullScreen mozallowfullscreen
         allowfullscreen> </iframe>","large_thumbnail_width":512,"embed_url":"http://www.hulu.com/embed.html?eid=CbtnRM8PBJsCfZpUy2V3Yg","air_date":"Thu
         Oct 13 00:00:00 UTC 2011","large_thumbnail_height":288,"thumbnail_url":"http://ib.huluim.com/video/50172061?size=145x80&caller=h1o&img=i","author_name":"NBC","provider_name":"Hulu","title":"Remedial
         Chaos Theory (Community)","thumbnail_width":145,"provider_url":"http://www.hulu.com/","duration":1286.87,"version":"1.0","thumbnail_height":80,"width":512}'
     http_version: 
-  recorded_at: Sun, 13 Apr 2014 22:40:14 GMT
+  recorded_at: Tue, 15 Apr 2014 02:52:18 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/murmuration.yml
+++ b/spec/cassettes/murmuration.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://vimeo.com/api/oembed.json?url=https://vimeo.com/31158841&width=400
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Age:
+      - '1'
+      Date:
+      - Tue, 15 Apr 2014 02:52:16 GMT
+      Expires:
+      - Tue, 15 Apr 2014 02:53:16 GMT
+      Content-Length:
+      - '793'
+      Connection:
+      - Keep-Alive
+      Via:
+      - 1.1 varnish
+      - dnet-dca
+      Etag:
+      - ! '"e19e6eea37661a8e029d8f8e3b2116f3e97ea8f0"'
+      Server:
+      - Apache
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Access-Control-Allow-Headers:
+      - X-Requested-With
+      Last-Modified:
+      - Tue, 15 Apr 2014 02:10:30 GMT
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - application/json
+      X-Varnish:
+      - '1677378251'
+      X-Varnish-Cache:
+      - '0'
+      Nncoection:
+      - close
+      X-Vserver:
+      - 10.90.128.197
+    body:
+      encoding: US-ASCII
+      string: ! '{"type":"video","version":"1.0","provider_name":"Vimeo","provider_url":"https:\/\/vimeo.com\/","title":"Murmuration","author_name":"Islands
+        & Rivers","author_url":"http:\/\/vimeo.com\/islandsandrivers","is_plus":"1","html":"<iframe
+        src=\"\/\/player.vimeo.com\/video\/31158841\" width=\"400\" height=\"300\"
+        frameborder=\"0\" title=\"Murmuration\" webkitallowfullscreen mozallowfullscreen
+        allowfullscreen><\/iframe>","width":400,"height":300,"duration":123,"description":"www.islandsandrivers.com\n\nFacebook:
+        Islands And Rivers\n\nFollow us @Islands_Rivers\n\nA chance encounter and
+        shared moment with one of natures greatest and most fleeting phenomena.","thumbnail_url":"http:\/\/i.vimeocdn.com\/video\/448600816_295x166.jpg","thumbnail_width":295,"thumbnail_height":221,"video_id":31158841}'
+    http_version: 
+  recorded_at: Tue, 15 Apr 2014 02:52:17 GMT
+recorded_with: VCR 2.9.0

--- a/spec/cassettes/murmuration2.yml
+++ b/spec/cassettes/murmuration2.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://vimeo.com/api/oembed.json?url=https://vimeo.com/31158841&width=500
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Access-Control-Allow-Headers:
+      - X-Requested-With
+      Expires:
+      - Tue, 15 Apr 2014 02:52:58 GMT
+      Last-Modified:
+      - Tue, 15 Apr 2014 02:10:30 GMT
+      Etag:
+      - ! '"e19e6eea37661a8e029d8f8e3b2116f3e97ea8f0"'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Apr 2014 02:52:16 GMT
+      X-Varnish:
+      - 2146795868 2146790599
+      Age:
+      - '18'
+      Via:
+      - 1.1 varnish
+      X-Varnish-Cache:
+      - '1'
+      Nncoection:
+      - close
+      X-Vserver:
+      - 10.90.128.188
+    body:
+      encoding: US-ASCII
+      string: ! '{"type":"video","version":"1.0","provider_name":"Vimeo","provider_url":"https:\/\/vimeo.com\/","title":"Murmuration","author_name":"Islands
+        & Rivers","author_url":"http:\/\/vimeo.com\/islandsandrivers","is_plus":"1","html":"<iframe
+        src=\"\/\/player.vimeo.com\/video\/31158841\" width=\"500\" height=\"375\"
+        frameborder=\"0\" title=\"Murmuration\" webkitallowfullscreen mozallowfullscreen
+        allowfullscreen><\/iframe>","width":500,"height":375,"duration":123,"description":"www.islandsandrivers.com\n\nFacebook:
+        Islands And Rivers\n\nFollow us @Islands_Rivers\n\nA chance encounter and
+        shared moment with one of natures greatest and most fleeting phenomena.","thumbnail_url":"http:\/\/i.vimeocdn.com\/video\/448600816_295x166.jpg","thumbnail_width":295,"thumbnail_height":221,"video_id":31158841}'
+    http_version: 
+  recorded_at: Tue, 15 Apr 2014 02:52:17 GMT
+recorded_with: VCR 2.9.0

--- a/spec/cassettes/stephen.yml
+++ b/spec/cassettes/stephen.yml
@@ -15,19 +15,15 @@ http_interactions:
       Server:
       - Apache
       Access-Control-Allow-Origin:
-      - '*'
+      - ! '*'
       Access-Control-Allow-Headers:
       - X-Requested-With
       Expires:
-      - Sun, 13 Apr 2014 22:40:15 GMT
+      - Tue, 15 Apr 2014 02:53:16 GMT
       Last-Modified:
       - Sun, 13 Apr 2014 19:06:59 GMT
       Etag:
-      - '"3ee9abac968dd90ff3d61a6c3ed1e6aac5a93a7d"'
-      X-Ua-Compatible:
-      - IE=edge
-      X-Dns-Prefetch-Control:
-      - 'on'
+      - ! '"3ee9abac968dd90ff3d61a6c3ed1e6aac5a93a7d"'
       Vary:
       - Accept-Encoding
       Content-Type:
@@ -35,22 +31,22 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Sun, 13 Apr 2014 22:39:15 GMT
+      - Tue, 15 Apr 2014 02:52:16 GMT
       X-Varnish:
-      - '2109561577'
+      - '273732503'
       Age:
       - '0'
       Via:
       - 1.1 varnish
       X-Varnish-Cache:
       - '0'
-      Nncoection:
+      Cneonction:
       - close
       X-Vserver:
-      - 10.90.128.188
+      - 10.90.128.147
     body:
-      encoding: UTF-8
-      string: '{"type":"video","version":"1.0","provider_name":"Vimeo","provider_url":"https:\/\/vimeo.com\/","title":"Days
+      encoding: US-ASCII
+      string: ! '{"type":"video","version":"1.0","provider_name":"Vimeo","provider_url":"https:\/\/vimeo.com\/","title":"Days
         Like Today","author_name":"Stephen_Scott_Day","author_url":"http:\/\/vimeo.com\/stephenscottday","is_plus":"1","html":"<iframe
         src=\"\/\/player.vimeo.com\/video\/16010689\" width=\"1280\" height=\"720\"
         frameborder=\"0\" title=\"Days Like Today\" webkitallowfullscreen mozallowfullscreen
@@ -59,5 +55,5 @@ http_interactions:
         the whole thing, but if you do, lemme know. \n\nTuesday, October 19th, 2010.
         Somewhere between 3:40pm and 3:50pm. Alhambra, CA.","thumbnail_url":"http:\/\/i.vimeocdn.com\/video\/97388869_1280.jpg","thumbnail_width":1280,"thumbnail_height":720,"video_id":16010689}'
     http_version: 
-  recorded_at: Sun, 13 Apr 2014 22:39:15 GMT
+  recorded_at: Tue, 15 Apr 2014 02:52:17 GMT
 recorded_with: VCR 2.9.0

--- a/spec/film_snob_spec.rb
+++ b/spec/film_snob_spec.rb
@@ -94,7 +94,17 @@ describe FilmSnob do
       expect(snob2.site).to eq :vimeo
       expect(snob2.clean_url).to eq 'https://vimeo.com/51020067'
     end
-
+    
+    it 'should allow oembed configuration' do
+      snob = FilmSnob.new("http://vimeo.com/31158841", width: 400)
+      VCR.use_cassette "murmuration" do
+        expect(snob.html).to match %r{width="400"}
+      end
+      snob2 = FilmSnob.new("http://vimeo.com/31158841", width: 500)
+      VCR.use_cassette "murmuration2" do
+        expect(snob2.html).to match %r{width="500"}
+      end
+    end
 
   end
 


### PR DESCRIPTION
FilmSnob now takes an options hash, which is directly forwarded to the oembed endpoint.

This assumes some familiarity with the endpoint's API.

This PR also has some unrelated refactoring.

closes #7
