### PR TITLE
Add support instagram video site

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ film_snob uses the oembed protocol to get html for embed codes. These options as
 * Hulu
 * Funny or Die
 * Coub
+* Instagram
 
 The same methods work with all of these providers.
 

--- a/lib/film_snob/instagram.rb
+++ b/lib/film_snob/instagram.rb
@@ -1,0 +1,28 @@
+require "film_snob/video_site"
+
+class FilmSnob
+  class Instagram < VideoSite
+    def self.valid_url_patterns
+      [
+        %r{http?://(?:(?:www).)?instagram.com/p/(\w+)},
+        %r{http?://(?:(?:www).)?instagr.am/p/(\w+)}
+      ]
+    end
+
+    def self.oembed_endpoint
+      'http://api.instagram.com/oembed'
+    end
+
+    def clean_url
+      @clean_url ||= "http://instagram.com/p/#{id}"
+    end
+
+    def html
+      if id
+        "<iframe src=\"//instagram.com/p/#{id}/embed/\" width=\"612\" height=\"710\" frameborder=\"0\" scrolling=\"no\" allowtransparency=\"true\"></iframe>"
+      else
+        raise NotEmbeddableError.new("#{clean_url} is not embeddable")
+      end
+    end
+  end
+end

--- a/lib/film_snob/url_to_video.rb
+++ b/lib/film_snob/url_to_video.rb
@@ -1,6 +1,7 @@
 require "film_snob/coub"
 require "film_snob/funny_or_die"
 require "film_snob/hulu"
+require "film_snob/instagram"
 require "film_snob/vimeo"
 require "film_snob/youtube"
 
@@ -12,7 +13,8 @@ class FilmSnob
       YouTube,
       Hulu,
       FunnyOrDie,
-      Coub
+      Coub,
+      Instagram
     ]
 
     attr_reader :url, :options

--- a/spec/cassettes/sphynx_cat.yml
+++ b/spec/cassettes/sphynx_cat.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.instagram.com/oembed?url=http://instagram.com/p/oBkLq7hnDP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Access-Control-Allow-Headers:
+      - X-Requested-With
+      Expires:
+      - Tue, 15 Apr 2014 02:53:16 GMT
+      Last-Modified:
+      - Sun, 13 Apr 2014 19:06:59 GMT
+      Etag:
+      - ! '"3ee9abac968dd90ff3d61a6c3ed1e6aac5a93a7d"'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 15 Apr 2014 02:52:16 GMT
+      X-Varnish:
+      - '273732503'
+      Age:
+      - '0'
+      Via:
+      - 1.1 varnish
+      X-Varnish-Cache:
+      - '0'
+      Cneonction:
+      - close
+      X-Vserver:
+      - 10.90.128.147
+    body:
+      encoding: UTF-8
+      string: |
+        {"provider_url":"http://instagram.com/","media_id":"721016547040456911_195995411","title":"Very stupid package!","url":"http://videos-h-17.ak.instagram.com/hphotos-ak-xpa1/10357107_1419962164942557_1070438508_n.mp4","author_name":"bonch_bruevich","height":640,"width":640,"version":"1.0","author_url":"http://instagram.com/bonch_bruevich","author_id":195995411,"type":"photo","provider_name":"Instagram"}
+    http_version:
+  recorded_at: Sun, 01 Jun 2014 02:52:17 GMT
+recorded_with: VCR 2.9.0

--- a/spec/film_snob_spec.rb
+++ b/spec/film_snob_spec.rb
@@ -132,6 +132,18 @@ describe FilmSnob do
     end
   end
 
+  describe 'instagram URLs' do
+    it 'should parse instagram URLs' do
+      film = FilmSnob.new("http://instagram.com/p/oBkLq7hnDP/")
+      expect(film.id).to eq 'oBkLq7hnDP'
+      expect(film.site).to eq :instagram
+      VCR.use_cassette 'sphynx cat' do
+        expect(film.title).to eq "Very stupid package!"
+        expect{film.html}.not_to raise_error
+      end
+    end
+  end
+
   describe 'coub URLs' do
     it 'should parse coub URLs' do
       film = FilmSnob.new("http://coub.com/view/rcd14cm")


### PR DESCRIPTION
Add instagram service. Because instagram API not send embed html in json response and embed html created on client, I just as create it in method `html`
