### PR TITLE
Turn off the hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-ruby:
-  enabled: true
-  config_file: .rubocop.yml


### PR DESCRIPTION
It wasn't respecting my .rubocop.yml configuration file, so it was leaving unhelpful comments. I already turned it off on the website, so now I'm removing this artifact of those days.

I'm leaving the rubocop config, and I'm still having it auto-run on Travis, so consistent style will still be enforced. People will just have to figure out why their builds are failing.
