### PR TITLE
Add default value to video site options

### DIFF
--- a/lib/film_snob/video_site.rb
+++ b/lib/film_snob/video_site.rb
@@ -4,7 +4,7 @@ require "json"
 class FilmSnob
   class VideoSite
     attr_reader :url, :options
-    def initialize(url, options)
+    def initialize(url, options = {})
       @url = url
       @options = options
     end


### PR DESCRIPTION
Why not, right? and it allows a simpler interface to access the
subclasses directly, eg:

``` ruby
FilmSnob::YouTube.new('https://www.youtube.com/watch?v=kwYpXVIqzso').html
```

instead of

``` ruby
FilmSnob::YouTube.new('https://www.youtube.com/watch?v=kwYpXVIqzso', {}).html
```

That's nice, not having to provide an empty hash

Noticed this while reviewing old issues, specifically https://github.com/maxjacobson/film_snob/issues/26 which suggests encouraging people to use this interface
