### PR TITLE
Use Forwardable to perform delegations

### DIFF
--- a/lib/film_snob.rb
+++ b/lib/film_snob.rb
@@ -4,9 +4,15 @@ require "film_snob/exceptions"
 require "film_snob/deprecated"
 
 class FilmSnob
-  attr_reader :url
+  extend Deprecated, Forwardable
 
-  extend Deprecated
+  VIDEO_METHODS = [:site, :id, :clean_url, :title, :html]
+
+  def_delegators :video, *VIDEO_METHODS
+
+  deprecated_alias :watchable?, :embeddable?, removed_in: "v1.0.0"
+
+  attr_reader :url
 
   def initialize(url, options = {})
     @url = url
@@ -17,16 +23,6 @@ class FilmSnob
     !@video.nil?
   end
 
-  deprecated_alias :watchable?, :embeddable?, removed_in: "v1.0.0"
-
-  def method_missing(message)
-    if delegated_video_methods.include?(message)
-      video.send(message)
-    else
-      super
-    end
-  end
-
   private
 
   def video
@@ -35,10 +31,6 @@ class FilmSnob
     else
       raise NotSupportedURLError, "#{url} is not a supported URL"
     end
-  end
-
-  def delegated_video_methods
-    [:site, :id, :clean_url, :title, :html]
   end
 end
 


### PR DESCRIPTION
This pull request replaces `method_missing` in favour of `Forwardable` to perform delegation to the `video`.

Closes #40 :smiley: 