### PR TITLE
Resolve Forwardable NameError

### DIFF
--- a/lib/film_snob.rb
+++ b/lib/film_snob.rb
@@ -1,3 +1,4 @@
+require "forwardable"
 require "film_snob/version"
 require "film_snob/url_to_video"
 require "film_snob/exceptions"


### PR DESCRIPTION
This fails:

gem install film_snob
irb
require 'film_snob'